### PR TITLE
IPv4/6 info print & UBLOX ODIN EMAC note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Add the following to your ``mbed_app.json`` file:
     }
 }
 ```
+If you choose `ETHERNET` with `UBLOX_ODIN_EVK_W2` you must add this to your `target-overrides` section in `mbed_app.json`:
+```json
+            "UBLOX_EVK_ODIN_W2": {
+            "target.device_has_remove": ["EMAC"]
+```
 
 If you choose `WIFI_ESP8266` or `WIFI_ODIN`, you'll also need to add the WiFi SSID and password:
 

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -71,7 +71,13 @@ NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCL
 NetworkInterface* easy_connect(bool log_messages = false) {
     NetworkInterface* network_interface = 0;
     int connect_success = -1;
-#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
+    /// This should be removed once mbedOS supports proper dual-stack
+#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+    printf("[EasyConnect] IPv6 mode\n");
+#else
+    printf("[EasyConnect] IPv4 mode\n");
+#endif
+    #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
     if (log_messages) {
         printf("[EasyConnect] Using WiFi (ESP8266) \n");
         printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);


### PR DESCRIPTION
2 separate changes;
1) IPv4/IPv6 info print to easy-connect
2) Add note about the EMAC removal if you are using UBLOX_ODIN_EWK_V2 and Ethernet.
