### PR TITLE
ESP8266 driver updates

### DIFF
--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/esp8266-driver/#4ed87bf7fe37d5ba0de6c4e78868f604a82f8ecb
+https://github.com/ARMmbed/esp8266-driver/#918caa01b4cdd3e798ac593b14687b9a94974074


### PR DESCRIPTION
There are massive improvements to the ESP8266 driver that need to be taken into use, especially the 2.0 Espressif firmware support.