### PR TITLE
Enable REALTEK_RTL8195AM WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your ``mbed_app.json`` file:
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN, WIFI_REALTEK, MESH_LOWPAN_ND,MESH_THREAD",
             "value": "ETHERNET"
         }
     },
@@ -29,12 +29,12 @@ If you choose `ETHERNET` with `UBLOX_ODIN_EVK_W2` you must add this to your `tar
             "target.device_has_remove": ["EMAC"]
 ```
 
-If you choose `WIFI_ESP8266` or `WIFI_ODIN`, you'll also need to add the WiFi SSID and password:
+If you choose `WIFI_ESP8266`, `WIFI_ODIN` or `WIFI_REALTEK`, you'll also need to add the WiFi SSID and password:
 
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,WIFI_REALTEK,MESH_LOWPAN_ND,MESH_THREAD",
             "value": "WIFI_ESP8266"
         },
         "esp8266-tx": {

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -8,6 +8,7 @@
 #define MESH_LOWPAN_ND  3
 #define MESH_THREAD     4
 #define WIFI_ODIN       5
+#define WIFI_REALTEK    6
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
 #include "ESP8266Interface.h"
@@ -20,7 +21,11 @@ ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
 #include "OdinWiFiInterface.h"
+
 OdinWiFiInterface wifi;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_REALTEK
+#include "RTWInterface.h"
+RTWInterface wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
 #include "EthernetInterface.h"
 EthernetInterface eth;
@@ -102,7 +107,7 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     printf("[EasyConnect] IPv4 mode\n");
 #endif
 
-    #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
+ #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
     if (log_messages) {
         printf("[EasyConnect] Using WiFi (ESP8266) \n");
         printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
@@ -116,6 +121,13 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     }
     network_interface = &wifi;
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_REALTEK
+    if (log_messages) {
+        printf("[EasyConnect] Using WiFi (REALTEK)\n");
+        printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
+    }
+    network_interface = &wifi;
+    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
     if (log_messages) {
         printf("[EasyConnect] Using Ethernet\n");
@@ -123,6 +135,7 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     network_interface = &eth;
     connect_success = eth.connect();
 #endif
+
 #ifdef MESH
     if (log_messages) {
         printf("[EasyConnect] Using Mesh\n");


### PR DESCRIPTION
Changes needed for the addition of the RTL Wifi-stack to enable REALTEK_RTL8195AM.
README.md also updated.