### PR TITLE
ESP8266 v1.3 lib

### DIFF
--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/esp8266-driver/#918caa01b4cdd3e798ac593b14687b9a94974074
+https://github.com/ARMmbed/esp8266-driver/#cac4d0d8f97745fe9a613b705b406646aeacc3e2


### PR DESCRIPTION
2da720a readme: Removed quotes from ssid/pass defines
6081f72 Add better documentation over the network tests
a38dbba Fixed small issues revealed in tests
d4cafb5 Added the network tests from mbed OS
c588afe Reverting CIPSENDBUF to CIPSEND to fix UDP connections. Tested on both UDP and TCP.
530ab25 Get firmware version occurs after reset
a7016f7 Ensures ES8266 firmware version up to date
abd4594 Fixed small issues missed in previous review
26581eb Style changes
1240d82 Driver compatible with 2.0 Espressif firmware.