### PR TITLE
Rename WIFI_REALTEK to WIFI_RTW

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `mbed_app.json` file:
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN, WIFI_REALTEK, MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND,MESH_THREAD",
             "value": "ETHERNET"
         }
     },
@@ -37,7 +37,7 @@ If you select `WIFI_ESP8266`, `WIFI_ODIN` or `WIFI_REALTEK`, you also need to ad
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_REALTEK, MESH_LOWPAN_ND, MESH_THREAD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "WIFI_ESP8266"
         },
         "esp8266-tx": {
@@ -65,7 +65,7 @@ If you use `MESH_LOWPAN_ND` or `MESH_THREAD` you need to specify your radio modu
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,WIFI_RTW,MESH_LOWPAN_ND,MESH_THREAD",
             "value": "MESH_LOWPAN_ND"
         },
         "mesh_radio_type": {

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -23,7 +23,7 @@ ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
 #include "OdinWiFiInterface.h"
 
 OdinWiFiInterface wifi;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_REALTEK
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
 #include "RTWInterface.h"
 RTWInterface wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
@@ -121,9 +121,9 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     }
     network_interface = &wifi;
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_REALTEK
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
     if (log_messages) {
-        printf("[EasyConnect] Using WiFi (REALTEK)\n");
+        printf("[EasyConnect] Using WiFi (RTW)\n");
         printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
     }
     network_interface = &wifi;


### PR DESCRIPTION
According to the actual name of the WIFI-stack. Based on review comments from
Jan Jongboom. This also aligns the naming with what we have with ESP8266 and Odin.
The actual network stack class name defines the configuration name.