### PR TITLE
ESP8266 - gethostbyname fix

### DIFF
--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/esp8266-driver/#cac4d0d8f97745fe9a613b705b406646aeacc3e2
+https://github.com/ARMmbed/esp8266-driver/#ebc1fbd0b53a132f6a753f619bd1a2244f1a2299


### PR DESCRIPTION
Any DNS query longer than 63 characters will fail with ESP8266 unless this fix is taken it.