### PR TITLE
Adding SiLabs EFR32 radio.

### DIFF
--- a/easy-connect.h
+++ b/easy-connect.h
@@ -53,6 +53,9 @@ NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, M
 #include "NanostackRfPhySpirit1.h"
 NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCLK,
 			     SPIRIT1_DEV_IRQ, SPIRIT1_DEV_CS, SPIRIT1_DEV_SDN, SPIRIT1_BRD_LED);
+#elif MBED_CONF_APP_MESH_RADIO_TYPE == EFR32
+#include "NanostackRfPhyEfr32.h"
+NanostackRfPhyEfr32 rf_phy;
 #endif //MBED_CONF_APP_RADIO_TYPE
 #endif //MESH
 


### PR DESCRIPTION
Adding SiLabs EFR32 radio as part of enabling mbed Client on new Thunderboard Sense 2 board with on-board radio (mighty gecko). The new target is already enabled in mbed OS 5.5 as "TB_SENSE_12".

Tested for full operation (K64F+AT233 Thread border router with Thunderboard Sense 2 and mDC registers device successfully and all resources visible on mDC) with this (easy-connect.h) and other changes to simpleclient.h and configs\mesh_thread.json. The other changes to the simple client and configs\mesh_thread.json files will be part of a separate PR. Splitting changes into multiple PR's to ease maintenance.

@JanneKiiskila  @yogpan01 . Could you please review and merge if all OK? Thanks.