### PR TITLE
MCR20A driver - compiler warning fixes

### DIFF
--- a/mcr20a-rf-driver.lib
+++ b/mcr20a-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mcr20a-rf-driver/#d5905fefa54c0de9b757d6f1c87c8ae9ee337543
+https://github.com/ARMmbed/mcr20a-rf-driver/#9aac10474702659c20bde3d2f444f14af440a2c9


### PR DESCRIPTION
[ONME-3113] Fix GCC_ARM and ARM compiler warnings