### PR TITLE
Define macros for RF drivers

### DIFF
--- a/easy-connect.h
+++ b/easy-connect.h
@@ -42,6 +42,13 @@ ThreadInterface mesh;
 #endif
 
 #if defined(MESH)
+
+// Define macros for radio type
+#define ATMEL   1
+#define MCR20   2
+#define SPIRIT1 3
+#define EFR32   4
+
 #if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
 #include "NanostackRfPhyAtmel.h"
 NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,


### PR DESCRIPTION
The easy connect header does not define values for RF type macros.
This must be defined, else all undefined macros will be replaced with value zero by the C preprocessor.

So the [RF selection](https://github.com/ARMmbed/easy-connect/blob/master/easy-connect.h#L45) becomes
```
#if 0 == 0
...
#elif 0 == 0
...
#elif 0 == 0
```
which always selects the first one.
