### PR TITLE
Add CELLULAR_ONBOARD as an interface option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `mbed_app.json` file:
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "ETHERNET"
         }
     },
@@ -37,7 +37,7 @@ If you select `WIFI_ESP8266`, `WIFI_ODIN` or `WIFI_RTW`, you also need to add th
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "WIFI_ESP8266"
         },
         "esp8266-tx": {
@@ -65,7 +65,7 @@ If you use `MESH_LOWPAN_ND` or `MESH_THREAD` you need to specify your radio modu
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,WIFI_RTW,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "MESH_LOWPAN_ND"
         },
         "mesh_radio_type": {
@@ -74,6 +74,40 @@ If you use `MESH_LOWPAN_ND` or `MESH_THREAD` you need to specify your radio modu
         }
     }
 ```
+
+If you use `CELLULAR_ONBOARD` (for which user documentation can be found [here](https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/communication/cellular/)) you must specify the following:
+
+```json
+    "target_overrides": {
+        "*": {
+            "ppp-cell-iface.apn-lookup": true
+        }
+    }
+```
+...and you may also need to specify one or more of the following:
+
+```json
+    "config": {
+        "cellular-apn": {
+            "help": "Please provide the APN string for your SIM if it is not already included in APN_db.h.",
+            "value": "\"my_sims_apn\""
+        },
+        "cellular-username": {
+            "help": "May or may not be required for your APN, please consult your SIM provider.",
+            "value": "\"my_sim_apns_username\""
+        },
+        "cellular-password": {
+            "help": "May or may not be required for your APN, please consult your SIM provider.",
+            "value": "\"my_sim_apns_password\""
+        },
+        "cellular-sim-pin": {
+            "help": "Please provide the PIN for your SIM (as a four digit string) if your SIM is normally locked",
+            "value": "\"1234\""
+        }
+    }
+```
+
+None of the optional settings need to be specified for the `UBLOX_C030_U201` cellular target, for which the APN settings are in `APN_db.h`.
 
 ## Using Easy Connect from your application
 

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -3,12 +3,13 @@
 
 #include "mbed.h"
 
-#define ETHERNET        1
-#define WIFI_ESP8266    2
-#define MESH_LOWPAN_ND  3
-#define MESH_THREAD     4
-#define WIFI_ODIN       5
-#define WIFI_REALTEK    6
+#define ETHERNET          1
+#define WIFI_ESP8266      2
+#define MESH_LOWPAN_ND    3
+#define MESH_THREAD       4
+#define WIFI_ODIN         5
+#define WIFI_REALTEK      6
+#define CELLULAR_ONBOARD  7
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
 #include "ESP8266Interface.h"
@@ -37,6 +38,9 @@ LoWPANNDInterface mesh;
 #define MESH
 #include "NanostackInterface.h"
 ThreadInterface mesh;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
+#include "OnboardCellularInterface.h"
+OnboardCellularInterface cellular;
 #else
 #error "No connectivity method chosen. Please add 'config.network-interfaces.value' to your mbed_app.json (see README.md for more information)."
 #endif
@@ -89,6 +93,7 @@ NanostackRfPhyEfr32 rf_phy;
  *
  */
 void print_MAC(NetworkInterface* network_interface, bool log_messages) {
+#if MBED_CONF_APP_NETWORK_INTERFACE != CELLULAR_ONBOARD
     const char *mac_addr = network_interface->get_mac_address();
     if (mac_addr == NULL) {
         if (log_messages) {
@@ -99,6 +104,7 @@ void print_MAC(NetworkInterface* network_interface, bool log_messages) {
     if (log_messages) {
         printf("[EasyConnect] MAC address %s\n", mac_addr);
     }
+#endif
 }
 
 
@@ -138,6 +144,28 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     }
     network_interface = &wifi;
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
+#  ifdef MBED_CONF_APP_CELLULAR_SIM_PIN
+    cellular.set_sim_pin(MBED_CONF_APP_CELLULAR_SIM_PIN);
+#  endif
+#  ifdef MBED_CONF_APP_CELLULAR_APN
+#    ifndef MBED_CONF_APP_CELLULAR_USERNAME
+#      define MBED_CONF_APP_CELLULAR_USERNAME 0
+#    endif
+#    ifndef MBED_CONF_APP_CELLULAR_PASSWORD
+#      define MBED_CONF_APP_CELLULAR_PASSWORD 0
+#    endif
+    cellular.set_credentials(MBED_CONF_APP_CELLULAR_APN, MBED_CONF_APP_CELLULAR_USERNAME, MBED_CONF_APP_CELLULAR_PASSWORD);
+    if (log_messages) {
+        printf("[EasyConnect] Connecting using Cellular interface and APN %s\n", MBED_CONF_APP_CELLULAR_APN);
+    }
+#  else
+    if (log_messages) {
+        printf("[EasyConnect] Connecting using Cellular interface and default APN\n");
+    }
+#  endif
+    connect_success = cellular.connect();
+    network_interface = &cellular;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
     if (log_messages) {
         printf("[EasyConnect] Using Ethernet\n");
@@ -174,6 +202,7 @@ NetworkInterface* easy_connect(bool log_messages = false) {
         }
         return NULL;
     }
+
     if (log_messages) {
         printf("[EasyConnect] IP address %s\n", ip_addr);
     }


### PR DESCRIPTION
Add Cellular as an easy-connect interface option, using the standard mbed-os PPP cellular API.  Tested with `mbed-os-example-client` and a `UBLOX_C030_U201` target.