### PR TITLE
Fix Realtek wifi macro name

### DIFF
--- a/easy-connect.h
+++ b/easy-connect.h
@@ -8,7 +8,7 @@
 #define MESH_LOWPAN_ND    3
 #define MESH_THREAD       4
 #define WIFI_ODIN         5
-#define WIFI_REALTEK      6
+#define WIFI_RTW          6
 #define CELLULAR_ONBOARD  7
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266


### PR DESCRIPTION
The macro currently doesn't match anything else, causing builds to fail