### PR TITLE
Support for STM WiFi Expansion Boards

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,2 +1,0 @@
-wifi-x-nucleo-idw01m1/ATParser/*
-esp8266-driver/ESP8266/ATParser/*

--- a/.mbedignore
+++ b/.mbedignore
@@ -1,2 +1,2 @@
-wifi-x-nucleo-idw01m1/SPWF01SA/ATParser/*
+wifi-x-nucleo-idw01m1/ATParser/*
 esp8266-driver/ESP8266/ATParser/*

--- a/ATParser.lib
+++ b/ATParser.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/ATParser/
+https://github.com/ARMmbed/ATParser/#0a74c97ec36659abaa60f25db5f0431c3d054fe7

--- a/ATParser.lib
+++ b/ATParser.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/ATParser/#0a74c97ec36659abaa60f25db5f0431c3d054fe7

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `mbed_app.json` file:
 {
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW01M1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW0XX1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "ETHERNET"
         }
     },
@@ -32,12 +32,12 @@ If you select `ETHERNET` with `UBLOX_ODIN_EVK_W2` you must add this to your `tar
             }
 ```
 
-If you select `WIFI_ESP8266`, `WIFI_IDW01M1`, `WIFI_ODIN` or `WIFI_RTW`, you also need to add the WiFi SSID and password:
+If you select `WIFI_ESP8266`, `WIFI_IDW0XX1`, `WIFI_ODIN` or `WIFI_RTW`, you also need to add the WiFi SSID and password:
 
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW01M1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW0XX1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "WIFI_ESP8266"
         },
         "esp8266-tx": {
@@ -65,7 +65,7 @@ If you use `MESH_LOWPAN_ND` or `MESH_THREAD` you need to specify your radio modu
 ```json
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW01M1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW0XX1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "MESH_LOWPAN_ND"
         },
         "mesh_radio_type": {

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -10,7 +10,7 @@
 #define WIFI_ODIN         5
 #define WIFI_RTW          6
 #define CELLULAR_ONBOARD  7
-#define WIFI_IDW01M1      8
+#define WIFI_IDW0XX1      8
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
 #include "ESP8266Interface.h"
@@ -28,7 +28,7 @@ OdinWiFiInterface wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
 #include "RTWInterface.h"
 RTWInterface wifi;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW01M1
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
 #include "SpwfSAInterface.h"
 SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
@@ -148,9 +148,9 @@ NetworkInterface* easy_connect(bool log_messages = false) {
     }
     network_interface = &wifi;
     connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW01M1
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
     if (log_messages) {
-        printf("[EasyConnect] Using WiFi (X-NUCLEO-IDW01M1)\n");
+        printf("[EasyConnect] Using WiFi (X-NUCLEO-IDW0XX1)\n");
         printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
     }
     network_interface = &wifi;

--- a/stm-spirit1-rf-driver.lib
+++ b/stm-spirit1-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/stm-spirit1-rf-driver/
+https://github.com/ARMmbed/stm-spirit1-rf-driver/#0ff4ca7537f0f2e9137c61ac21251ac06ca42bc3

--- a/wifi-x-nucleo-idw01m1.lib
+++ b/wifi-x-nucleo-idw01m1.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/#f28c51f3e8e44211674a7d5c7409fa08b62e956a
+https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/#82ed479b9a5650b5bcb354aab34bc510741d3a76

--- a/wifi-x-nucleo-idw01m1.lib
+++ b/wifi-x-nucleo-idw01m1.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/#82ed479b9a5650b5bcb354aab34bc510741d3a76
+https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/#c6ef6b951c05318b81d72602a28625ed6cff9d0e

--- a/wifi-x-nucleo-idw01m1.lib
+++ b/wifi-x-nucleo-idw01m1.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/
+https://github.com/ARMmbed/wifi-x-nucleo-idw01m1/#f28c51f3e8e44211674a7d5c7409fa08b62e956a


### PR DESCRIPTION
Removes also the need for dedicated link to `ATParser`