### PR TITLE
Cleaner .h/.cpp, overloaded for WiFi parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,6 @@ If you select `WIFI_ESP8266`, `WIFI_IDW0XX1`, `WIFI_ODIN` or `WIFI_RTW`, you als
             "help": "options are ETHERNET, WIFI_ESP8266, WIFI_IDW0XX1, WIFI_ODIN, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD, CELLULAR_ONBOARD",
             "value": "WIFI_ESP8266"
         },
-        "esp8266-tx": {
-            "help": "Pin used as TX (connects to ESP8266 RX)",
-            "value": "PTD3"
-        },
-        "esp8266-rx": {
-            "help": "Pin used as RX (connects to ESP8266 TX)",
-            "value": "PTD2"
-        },
-        "esp8266-debug": {
-            "value": true
-        },
         "wifi-ssid": {
             "value": "\"SSID\""
         },
@@ -126,6 +115,48 @@ int main(int, char**) {
     // Rest of your program
 }
 ```
+
+## Using Easy connect with WiFi
+
+The easy-connect `easy_connect()` is overloaded now for WiFi so that you can submit your WiFi SSID and password programmatically in you want
+the user to be able to supply them via some means.
+
+```cpp
+#include "easy-connect.h"
+
+int main(int, char**) {
+    char* wifi_SSID = "SSID";
+    char* wifi_password = "password";
+
+    NetworkInterface* network = easy_connect(true, wifi_SSID, wifi_password); 
+    if (!network) {
+        printf("Connecting to the network failed... See serial output.\r\n");
+        return 1;
+    }
+
+    // Rest of your program
+}
+```
+
+## Overriding settings
+
+Easy-connect was changed recently with [PR #59](https://github.com/ARMmbed/easy-connect/pull/59) - where some of the defines expected via `mbed_app.json` were
+moved to the [`mbed_lib.json`](https://github.com/ARMmbed/easy-connect/blob/master/mbed_lib.json). 
+This minimises the amount of lines needed (in typical cases) in the applications `mbed_app.json`. However, due to this the overrides
+need to be done slightly differently, as you need to override the `easy-connect` defines.
+
+So, for example changing the ESP8266 TX/RX pins and enable debugs - you would now have modify as below.
+
+```json
+    "target_overrides": {
+        "*": {
+            "easy-connect.wifi-esp8266-tx": "A1",
+            "easy-connect.wifi-esp8266-rx": "A2",
+            "easy-connect.wifi-esp8266-debug: true
+         }
+    }
+```
+
 
 ## Configuration examples
 

--- a/easy-connect.cpp
+++ b/easy-connect.cpp
@@ -1,0 +1,289 @@
+/*
+ * FILE: easy-connect.cpp
+ *
+ * Copyright (c) 2015 - 2017 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "easy-connect.h"
+
+/*
+ * Instantiate the configured network interface
+ */
+#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
+#include "ESP8266Interface.h"
+
+#ifdef MBED_CONF_APP_ESP8266_DEBUG
+ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX, MBED_CONF_APP_ESP8266_DEBUG);
+#else
+ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
+#endif
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
+#include "OdinWiFiInterface.h"
+OdinWiFiInterface wifi;
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
+#include "RTWInterface.h"
+RTWInterface wifi;
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
+#include "SpwfSAInterface.h"
+SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+#include "EthernetInterface.h"
+EthernetInterface eth;
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
+#define MESH
+#include "NanostackInterface.h"
+LoWPANNDInterface mesh;
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
+#define MESH
+#include "NanostackInterface.h"
+ThreadInterface mesh;
+
+#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
+#include "OnboardCellularInterface.h"
+OnboardCellularInterface cellular;
+
+#else
+#error "No connectivity method chosen. Please add 'config.network-interfaces.value' to your mbed_app.json (see README.md for more information)."
+#endif // MBED_CONF_APP_NETWORK_INTERFACE
+
+/*
+ * In case of Mesh, instantiate the configured RF PHY.
+ */
+#if defined (MESH)
+#if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
+#include "NanostackRfPhyAtmel.h"
+NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
+                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
+
+#elif MBED_CONF_APP_MESH_RADIO_TYPE == MCR20
+#include "NanostackRfPhyMcr20a.h"
+NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
+
+#elif MBED_CONF_APP_MESH_RADIO_TYPE == SPIRIT1
+#include "NanostackRfPhySpirit1.h"
+NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCLK,
+                             SPIRIT1_DEV_IRQ, SPIRIT1_DEV_CS, SPIRIT1_DEV_SDN, SPIRIT1_BRD_LED);
+
+#elif MBED_CONF_APP_MESH_RADIO_TYPE == EFR32
+#include "NanostackRfPhyEfr32.h"
+NanostackRfPhyEfr32 rf_phy;
+
+#endif // MBED_CONF_APP_RADIO_TYPE
+#endif // MESH
+
+#if defined (WIFI)
+#define WIFI_SSID_MAX_LEN      32
+#define WIFI_PASSWORD_MAX_LEN  64
+
+char _ssid[WIFI_SSID_MAX_LEN+1] = {0};
+char _password[WIFI_PASSWORD_MAX_LEN+1] = {0};
+#endif // WIFI
+
+/* \brief print_MAC - print_MAC  - helper function to print out MAC address
+ * in: network_interface - pointer to network i/f
+ *     bool log-messages   print out logs or not
+ * MAC address is print, if it can be acquired & log_messages is true.
+ *
+ */
+void print_MAC(NetworkInterface* network_interface, bool log_messages) {
+#if MBED_CONF_APP_NETWORK_INTERFACE != CELLULAR_ONBOARD
+    const char *mac_addr = network_interface->get_mac_address();
+    if (mac_addr == NULL) {
+        if (log_messages) {
+            printf("[EasyConnect] ERROR - No MAC address\n");
+        }
+        return;
+    }
+    if (log_messages) {
+        printf("[EasyConnect] MAC address %s\n", mac_addr);
+    }
+#endif
+}
+
+
+
+/* \brief easy_connect     easy_connect() function to connect the pre-defined network bearer,
+ *                         config done via mbed_app.json (see README.md for details).
+ * IN: bool  log_messages  print out diagnostics or not.
+ */
+NetworkInterface* easy_connect(bool log_messages) {
+    NetworkInterface* network_interface = NULL;
+    int connect_success = -1;
+
+#if defined (WIFI)
+    // We check if the _ssid and _password have already been set (via the easy_connect() that takes thoses parameters or not
+    // If they have not been set, use the ones we can gain from mbed_app.json.
+    if (strlen(_ssid) == 0) { 
+        if(strlen(MBED_CONF_APP_WIFI_SSID) > WIFI_SSID_MAX_LEN) {
+            printf("WARNING - MBED_CONF_APP_WIFI_SSID is too long - it will be cut to %d chars.\n", WIFI_SSID_MAX_LEN);
+        }
+        strncpy(_ssid, MBED_CONF_APP_WIFI_SSID, WIFI_SSID_MAX_LEN);
+    }
+
+    if (strlen(_password) == 0 ) {
+        if(strlen(MBED_CONF_APP_WIFI_PASSWORD) > WIFI_PASSWORD_MAX_LEN) {
+            printf("WARNING - MBED_CONF_APP_WIFI_PASSWORD is too long - it will be cut to %d chars.\n", WIFI_PASSWORD_MAX_LEN);
+        }
+        strncpy(_password, MBED_CONF_APP_WIFI_PASSWORD, WIFI_PASSWORD_MAX_LEN);
+    }
+#endif // WIFI
+
+    /// This should be removed once mbedOS supports proper dual-stack
+#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+    printf("[EasyConnect] IPv6 mode\n");
+#else
+    printf("[EasyConnect] IPv4 mode\n");
+#endif
+
+#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
+    if (log_messages) {
+        printf("[EasyConnect] Using WiFi (ESP8266) \n");
+        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
+    }
+    network_interface = &wifi;
+    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
+    if (log_messages) {
+        printf("[EasyConnect] Using WiFi (ODIN) \n");
+        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
+    }
+    network_interface = &wifi;
+    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
+    if (log_messages) {
+        printf("[EasyConnect] Using WiFi (RTW)\n");
+        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
+    }
+    network_interface = &wifi;
+    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
+    if (log_messages) {
+        printf("[EasyConnect] Using WiFi (X-NUCLEO-IDW0XX1)\n");
+        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
+    }
+    network_interface = &wifi;
+    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
+#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
+#  ifdef MBED_CONF_APP_CELLULAR_SIM_PIN
+    cellular.set_sim_pin(MBED_CONF_APP_CELLULAR_SIM_PIN);
+#  endif
+#  ifdef MBED_CONF_APP_CELLULAR_APN
+#    ifndef MBED_CONF_APP_CELLULAR_USERNAME
+#      define MBED_CONF_APP_CELLULAR_USERNAME 0
+#    endif
+#    ifndef MBED_CONF_APP_CELLULAR_PASSWORD
+#      define MBED_CONF_APP_CELLULAR_PASSWORD 0
+#    endif
+    cellular.set_credentials(MBED_CONF_APP_CELLULAR_APN, MBED_CONF_APP_CELLULAR_USERNAME, MBED_CONF_APP_CELLULAR_PASSWORD);
+    if (log_messages) {
+        printf("[EasyConnect] Connecting using Cellular interface and APN %s\n", MBED_CONF_APP_CELLULAR_APN);
+    }
+#  else
+    if (log_messages) {
+        printf("[EasyConnect] Connecting using Cellular interface and default APN\n");
+    }
+#  endif
+    connect_success = cellular.connect();
+    network_interface = &cellular;
+#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
+    if (log_messages) {
+        printf("[EasyConnect] Using Ethernet\n");
+    }
+    network_interface = &eth;
+    connect_success = eth.connect();
+#endif
+
+#ifdef MESH
+    if (log_messages) {
+        printf("[EasyConnect] Using Mesh\n");
+        printf("[EasyConnect] Connecting to Mesh..\n");
+    }
+    network_interface = &mesh;
+    mesh.initialize(&rf_phy);
+    connect_success = mesh.connect();
+#endif
+    if(connect_success == 0) {
+        if (log_messages) {
+            printf("[EasyConnect] Connected to Network successfully\n");
+            print_MAC(network_interface, log_messages);
+        }
+    } else {
+        if (log_messages) {
+            print_MAC(network_interface, log_messages);
+            printf("[EasyConnect] Connection to Network Failed %d!\n", connect_success);
+        }
+        return NULL;
+    }
+    const char *ip_addr  = network_interface->get_ip_address();
+    if (ip_addr == NULL) {
+        if (log_messages) {
+            printf("[EasyConnect] ERROR - No IP address\n");
+        }
+        return NULL;
+    }
+
+    if (log_messages) {
+        printf("[EasyConnect] IP address %s\n", ip_addr);
+    }
+    return network_interface;
+}
+
+/* \brief easy_connect - easy_connect function to connect the pre-defined network bearer,
+ *                       config done via mbed_app.json (see README.md for details).
+ *                       This version is just a helper version and uses the easy_connect() with
+ *                       one parameters to do it's job.
+ * IN: bool  log_messages  print out diagnostics or not.
+ *     char* WiFiSSID      WiFi SSID - pointer to WiFi SSID, but if it is NULL  
+ *                         then MBED_CONF_APP_WIFI_SSID will be used
+ *     char* WiFiPassword  WiFi Password - pointer to WiFI password, but if it's NULL
+ *                         then MBED_CONF_APP_WIFI_PASSWORD will be used
+ */
+
+NetworkInterface* easy_connect(bool log_messages,
+                               char* WiFiSSID,
+                               char* WiFiPassword ) {
+
+
+#if defined (WIFI) // This function only makes sense when using WiFi
+    // We essentially want to populate the _ssid and _password and then call easy_connect() again. 
+    if (WiFiSSID != NULL) {
+        if(strlen(WiFiSSID) > WIFI_SSID_MAX_LEN) {
+            printf("WARNING - WiFi SSID is too long - it will be cut to %d chars.\n", WIFI_SSID_MAX_LEN);
+        }
+        strncpy(_ssid, WiFiSSID, WIFI_SSID_MAX_LEN);
+    }
+    else {
+        strncpy(_ssid, MBED_CONF_APP_WIFI_SSID, WIFI_SSID_MAX_LEN);
+    }
+
+    if (WiFiPassword != NULL) {
+        if(strlen(WiFiPassword) > WIFI_PASSWORD_MAX_LEN) {
+            printf("WARNING - WiFi Password is too long - it will be cut to %d chars.\n", WIFI_PASSWORD_MAX_LEN);
+        }
+        strncpy(_password, WiFiPassword, WIFI_PASSWORD_MAX_LEN);
+    }
+    else {
+        strncpy(_password, MBED_CONF_APP_WIFI_PASSWORD, WIFI_PASSWORD_MAX_LEN);
+    }
+#endif // WIFI
+    return easy_connect(log_messages);
+}

--- a/easy-connect.cpp
+++ b/easy-connect.cpp
@@ -24,6 +24,7 @@
  */
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
 #include "ESP8266Interface.h"
+#define WIFI_TYPE "ESP8266"
 
 #ifdef MBED_CONF_APP_ESP8266_DEBUG
 ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX, MBED_CONF_APP_ESP8266_DEBUG);
@@ -32,14 +33,17 @@ ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
 #endif
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
+#define WIFI_TYPE "Odin"
 #include "OdinWiFiInterface.h"
 OdinWiFiInterface wifi;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
+#define WIFI_TYPE "RTW"
 #include "RTWInterface.h"
 RTWInterface wifi;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
+#define WIFI_TYPE "IDW0XX1"
 #include "SpwfSAInterface.h"
 SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 
@@ -145,6 +149,7 @@ NetworkInterface* easy_connect(bool log_messages) {
         }
         strncpy(_password, MBED_CONF_APP_WIFI_PASSWORD, WIFI_PASSWORD_MAX_LEN);
     }
+    printf("_password = %s, len = %d\n", _password, strlen(_password));
 #endif // WIFI
 
     /// This should be removed once mbedOS supports proper dual-stack
@@ -154,30 +159,9 @@ NetworkInterface* easy_connect(bool log_messages) {
     printf("[EasyConnect] IPv4 mode\n");
 #endif
 
-#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
+#if defined (WIFI)
     if (log_messages) {
-        printf("[EasyConnect] Using WiFi (ESP8266) \n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (ODIN) \n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (RTW)\n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(_ssid, _password, (strlen(_password) > 1) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (X-NUCLEO-IDW0XX1)\n");
+        printf("[EasyConnect] Using WiFi (%s) \n", WIFI_TYPE);
         printf("[EasyConnect] Connecting to WiFi %s\n", _ssid);
     }
     network_interface = &wifi;

--- a/easy-connect.cpp
+++ b/easy-connect.cpp
@@ -24,7 +24,7 @@
  */
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
 #include "ESP8266Interface.h"
-#define WIFI_TYPE "ESP8266"
+#define EASY_CONNECT_WIFI_TYPE "ESP8266"
 
 #ifdef MBED_CONF_APP_ESP8266_DEBUG
 ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX, MBED_CONF_APP_ESP8266_DEBUG);
@@ -33,17 +33,17 @@ ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
 #endif
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
-#define WIFI_TYPE "Odin"
+#define EASY_CONNECT_WIFI_TYPE "Odin"
 #include "OdinWiFiInterface.h"
 OdinWiFiInterface wifi;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
-#define WIFI_TYPE "RTW"
+#define EASY_CONNECT_WIFI_TYPE "RTW"
 #include "RTWInterface.h"
 RTWInterface wifi;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
-#define WIFI_TYPE "IDW0XX1"
+#define EASY_CONNECT_WIFI_TYPE "IDW0XX1"
 #include "SpwfSAInterface.h"
 SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 
@@ -52,12 +52,12 @@ SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 EthernetInterface eth;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-#define MESH
+#define EASY_CONNECT_MESH
 #include "NanostackInterface.h"
 LoWPANNDInterface mesh;
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-#define MESH
+#define EASY_CONNECT_MESH
 #include "NanostackInterface.h"
 ThreadInterface mesh;
 
@@ -72,39 +72,39 @@ OnboardCellularInterface cellular;
 /*
  * In case of Mesh, instantiate the configured RF PHY.
  */
-#if defined (MESH)
+#if defined (EASY_CONNECT_MESH)
 #if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
 #include "NanostackRfPhyAtmel.h"
-#define MESH_TYPE "Atmel"
+#define EASY_CONNECT_MESH_TYPE "Atmel"
 NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
                            ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
 
 #elif MBED_CONF_APP_MESH_RADIO_TYPE == MCR20
 #include "NanostackRfPhyMcr20a.h"
-#define MESH_TYPE "Mcr20A"
+#define EASY_CONNECT_MESH_TYPE "Mcr20A"
 NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
 
 #elif MBED_CONF_APP_MESH_RADIO_TYPE == SPIRIT1
 #include "NanostackRfPhySpirit1.h"
-#define MESH_TYPE "Spirit1"
+#define EASY_CONNECT_MESH_TYPE "Spirit1"
 NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCLK,
                              SPIRIT1_DEV_IRQ, SPIRIT1_DEV_CS, SPIRIT1_DEV_SDN, SPIRIT1_BRD_LED);
 
 #elif MBED_CONF_APP_MESH_RADIO_TYPE == EFR32
 #include "NanostackRfPhyEfr32.h"
-#define MESH_TYPE "EFR32"
+#define EASY_CONNECT_MESH_TYPE "EFR32"
 NanostackRfPhyEfr32 rf_phy;
 
 #endif // MBED_CONF_APP_RADIO_TYPE
-#endif // MESH
+#endif // EASY_CONNECT_MESH
 
-#if defined (WIFI)
+#if defined (EASY_CONNECT_WIFI)
 #define WIFI_SSID_MAX_LEN      32
 #define WIFI_PASSWORD_MAX_LEN  64
 
 char* _ssid = NULL;
 char* _password = NULL;
-#endif // WIFI
+#endif // EASY_CONNECT_WIFI
 
 /* \brief print_MAC - print_MAC  - helper function to print out MAC address
  * in: network_interface - pointer to network i/f
@@ -137,7 +137,7 @@ NetworkInterface* easy_connect(bool log_messages) {
     NetworkInterface* network_interface = NULL;
     int connect_success = -1;
 
-#if defined (WIFI)
+#if defined (EASY_CONNECT_WIFI)
     // We check if the _ssid and _password have already been set (via the easy_connect() that takes thoses parameters or not
     // If they have not been set, use the ones we can gain from mbed_app.json.
     if (_ssid == NULL) { 
@@ -153,18 +153,18 @@ NetworkInterface* easy_connect(bool log_messages) {
             return 0;
         }
     }
-#endif // WIFI
+#endif // EASY_CONNECT_WIFI
 
     /// This should be removed once mbedOS supports proper dual-stack
-#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
+#if defined (EASY_CONNECT_MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
     printf("[EasyConnect] IPv6 mode\n");
 #else
     printf("[EasyConnect] IPv4 mode\n");
 #endif
 
-#if defined (WIFI)
+#if defined (EASY_CONNECT_WIFI)
     if (log_messages) {
-        printf("[EasyConnect] Using WiFi (%s) \n", WIFI_TYPE);
+        printf("[EasyConnect] Using WiFi (%s) \n", EASY_CONNECT_WIFI_TYPE);
         printf("[EasyConnect] Connecting to WiFi %s\n", ((_ssid == NULL) ? MBED_CONF_APP_WIFI_SSID : _ssid) );
     }
     network_interface = &wifi;
@@ -204,9 +204,9 @@ NetworkInterface* easy_connect(bool log_messages) {
     connect_success = eth.connect();
 #endif
 
-#ifdef MESH
+#ifdef EASY_CONNECT_MESH
     if (log_messages) {
-        printf("[EasyConnect] Using Mesh (%s)\n", MESH_TYPE);
+        printf("[EasyConnect] Using Mesh (%s)\n", EASY_CONNECT_MESH_TYPE);
         printf("[EasyConnect] Connecting to Mesh...\n");
     }
     network_interface = &mesh;
@@ -255,7 +255,7 @@ NetworkInterface* easy_connect(bool log_messages,
                                char* WiFiPassword ) {
 
 // This functionality only makes sense when using WiFi
-#if defined (WIFI) 
+#if defined (EASY_CONNECT_WIFI) 
     // We essentially want to populate the _ssid and _password and then call easy_connect() again. 
     if (WiFiSSID != NULL) {
         if(strlen(WiFiSSID) > WIFI_SSID_MAX_LEN) {
@@ -272,6 +272,6 @@ NetworkInterface* easy_connect(bool log_messages,
         }
         _password = WiFiPassword;
     }
-#endif // WIFI
+#endif // EASY_CONNECT_WIFI
     return easy_connect(log_messages);
 }

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -1,53 +1,54 @@
+/*
+ * FILE: easy-connect.h
+ *
+ * Copyright (c) 2015 - 2017 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef __EASY_CONNECT_H__
 #define __EASY_CONNECT_H__
 
 #include "mbed.h"
 
 #define ETHERNET          1
-#define WIFI_ESP8266      2
-#define MESH_LOWPAN_ND    3
-#define MESH_THREAD       4
-#define WIFI_ODIN         5
-#define WIFI_RTW          6
-#define CELLULAR_ONBOARD  7
-#define WIFI_IDW0XX1      8
+#define WIFI_ESP8266      11
+#define WIFI_ODIN         12
+#define WIFI_RTW          13
+#define WIFI_IDW0XX1      14
+#define MESH_LOWPAN_ND    101
+#define MESH_THREAD       102
+#define CELLULAR_ONBOARD  201
+
+/* Define supersets for WiFi and Mesh */
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
-#include "ESP8266Interface.h"
-
-#ifdef MBED_CONF_APP_ESP8266_DEBUG
-ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX, MBED_CONF_APP_ESP8266_DEBUG);
-#else
-ESP8266Interface wifi(MBED_CONF_APP_ESP8266_TX, MBED_CONF_APP_ESP8266_RX);
-#endif
+#define WIFI
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
-#include "OdinWiFiInterface.h"
+#define WIFI
 
-OdinWiFiInterface wifi;
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
-#include "RTWInterface.h"
-RTWInterface wifi;
+#define WIFI
+
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
-#include "SpwfSAInterface.h"
-SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-#include "EthernetInterface.h"
-EthernetInterface eth;
+#define WIFI
+
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
 #define MESH
-#include "NanostackInterface.h"
-LoWPANNDInterface mesh;
+
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
 #define MESH
-#include "NanostackInterface.h"
-ThreadInterface mesh;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
-#include "OnboardCellularInterface.h"
-OnboardCellularInterface cellular;
-#else
-#error "No connectivity method chosen. Please add 'config.network-interfaces.value' to your mbed_app.json (see README.md for more information)."
-#endif
+#endif // MBED_CONF_APP_NETWORK_INTERFACE
 
 #if defined(MESH)
 
@@ -57,37 +58,34 @@ OnboardCellularInterface cellular;
 #define SPIRIT1 3
 #define EFR32   4
 
-#if MBED_CONF_APP_MESH_RADIO_TYPE == ATMEL
-#include "NanostackRfPhyAtmel.h"
-NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
-                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
-#elif MBED_CONF_APP_MESH_RADIO_TYPE == MCR20
-#include "NanostackRfPhyMcr20a.h"
-NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
-#elif MBED_CONF_APP_MESH_RADIO_TYPE == SPIRIT1
-#include "NanostackRfPhySpirit1.h"
-NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCLK,
-			     SPIRIT1_DEV_IRQ, SPIRIT1_DEV_CS, SPIRIT1_DEV_SDN, SPIRIT1_BRD_LED);
-#elif MBED_CONF_APP_MESH_RADIO_TYPE == EFR32
-#include "NanostackRfPhyEfr32.h"
-NanostackRfPhyEfr32 rf_phy;
-#endif //MBED_CONF_APP_RADIO_TYPE
-#endif //MESH
+// This is address to mbed Device Connector (hard-coded IP due to DNS might not be there)
+#define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
 
-#ifndef MESH
-// This is address to mbed Device Connector
-#define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 #else
 // This is address to mbed Device Connector
-#define MBED_SERVER_ADDRESS "coaps://[2607:f0d0:2601:52::20]:5684"
+#define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
+
+#endif // (MESH)
+
+// In case the mbed_app.json only defined WIFI SSID/PASSWORD, not ESP8266 ones.
+#if not defined MBED_CONF_APP_ESP8266_SSID
+#define MBED_CONF_APP_ESP8266_SSID         MBED_CONF_APP_WIFI_SSID
+#else
+#define MBED_CONF_APP_WIFI_PASSWORD        MBED_CONF_APP_ESP8266_PASSWORD
 #endif
 
-#ifdef MBED_CONF_APP_ESP8266_SSID
-#define MBED_CONF_APP_WIFI_SSID MBED_CONF_APP_ESP8266_SSID
+#if not defined MBED_CONF_APP_ESP8266_PASSWORD
+#define MBED_CONF_APP_ESP8266_PASSWORD     MBED_CONF_APP_WIFI_PASSWORD
+#else
+#define MBED_CONF_APP_WIFI_SSID            MBED_CONF_APP_ESP8266_SSID
 #endif
 
-#ifdef MBED_CONF_APP_ESP8266_PASSWORD
-#define MBED_CONF_APP_WIFI_PASSWORD MBED_CONF_APP_ESP8266_PASSWORD
+#if not defined MBED_CONF_APP_ESP8266_TX
+#define MBED_CONF_APP_ESP8266_TX         MBED_CONF_APP_WIFI_TX
+#endif
+
+#if not defined MBED_CONF_APP_ESP8266_RX
+#define MBED_CONF_APP_ESP8266_RX         MBED_CONF_APP_WIFI_RX
 #endif
 
 /* \brief print_MAC - print_MAC  - helper function to print out MAC address
@@ -96,128 +94,24 @@ NanostackRfPhyEfr32 rf_phy;
  * MAC address is print, if it can be acquired & log_messages is true.
  *
  */
-void print_MAC(NetworkInterface* network_interface, bool log_messages) {
-#if MBED_CONF_APP_NETWORK_INTERFACE != CELLULAR_ONBOARD
-    const char *mac_addr = network_interface->get_mac_address();
-    if (mac_addr == NULL) {
-        if (log_messages) {
-            printf("[EasyConnect] ERROR - No MAC address\n");
-        }
-        return;
-    }
-    if (log_messages) {
-        printf("[EasyConnect] MAC address %s\n", mac_addr);
-    }
-#endif
-}
+void print_MAC(NetworkInterface* network_interface, bool log_messages);
 
 
 /* \brief easy_connect - easy_connect function to connect the pre-defined network bearer,
  *                       config done via mbed_app.json (see README.md for details).
- * IN: bool log_messages  print out diagnostics or not.
- *
+ * IN: bool  log_messages  print out diagnostics or not.
  */
-NetworkInterface* easy_connect(bool log_messages = false) {
-    NetworkInterface* network_interface = 0;
-    int connect_success = -1;
-    /// This should be removed once mbedOS supports proper dual-stack
-#if defined (MESH) || (MBED_CONF_LWIP_IPV6_ENABLED==true)
-    printf("[EasyConnect] IPv6 mode\n");
-#else
-    printf("[EasyConnect] IPv4 mode\n");
-#endif
+NetworkInterface* easy_connect(bool log_messages = false);
 
-#if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (ESP8266) \n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, (strlen(MBED_CONF_APP_WIFI_PASSWORD) > 2) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (ODIN) \n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, (strlen(MBED_CONF_APP_WIFI_PASSWORD) > 2) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (RTW)\n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, (strlen(MBED_CONF_APP_WIFI_PASSWORD) > 2) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
-    if (log_messages) {
-        printf("[EasyConnect] Using WiFi (X-NUCLEO-IDW0XX1)\n");
-        printf("[EasyConnect] Connecting to WiFi %s\n", MBED_CONF_APP_WIFI_SSID);
-    }
-    network_interface = &wifi;
-    connect_success = wifi.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, (strlen(MBED_CONF_APP_WIFI_PASSWORD) > 2) ? NSAPI_SECURITY_WPA_WPA2 : NSAPI_SECURITY_NONE);
-#elif MBED_CONF_APP_NETWORK_INTERFACE == CELLULAR_ONBOARD
-#  ifdef MBED_CONF_APP_CELLULAR_SIM_PIN
-    cellular.set_sim_pin(MBED_CONF_APP_CELLULAR_SIM_PIN);
-#  endif
-#  ifdef MBED_CONF_APP_CELLULAR_APN
-#    ifndef MBED_CONF_APP_CELLULAR_USERNAME
-#      define MBED_CONF_APP_CELLULAR_USERNAME 0
-#    endif
-#    ifndef MBED_CONF_APP_CELLULAR_PASSWORD
-#      define MBED_CONF_APP_CELLULAR_PASSWORD 0
-#    endif
-    cellular.set_credentials(MBED_CONF_APP_CELLULAR_APN, MBED_CONF_APP_CELLULAR_USERNAME, MBED_CONF_APP_CELLULAR_PASSWORD);
-    if (log_messages) {
-        printf("[EasyConnect] Connecting using Cellular interface and APN %s\n", MBED_CONF_APP_CELLULAR_APN);
-    }
-#  else
-    if (log_messages) {
-        printf("[EasyConnect] Connecting using Cellular interface and default APN\n");
-    }
-#  endif
-    connect_success = cellular.connect();
-    network_interface = &cellular;
-#elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET
-    if (log_messages) {
-        printf("[EasyConnect] Using Ethernet\n");
-    }
-    network_interface = &eth;
-    connect_success = eth.connect();
-#endif
-
-#ifdef MESH
-    if (log_messages) {
-        printf("[EasyConnect] Using Mesh\n");
-        printf("[EasyConnect] Connecting to Mesh..\n");
-    }
-    network_interface = &mesh;
-    mesh.initialize(&rf_phy);
-    connect_success = mesh.connect();
-#endif
-    if(connect_success == 0) {
-        if (log_messages) {
-            printf("[EasyConnect] Connected to Network successfully\n");
-            print_MAC(network_interface, log_messages);
-        }
-    } else {
-        if (log_messages) {
-            print_MAC(network_interface, log_messages);
-            printf("[EasyConnect] Connection to Network Failed %d!\n", connect_success);
-        }
-        return NULL;
-    }
-    const char *ip_addr  = network_interface->get_ip_address();
-    if (ip_addr == NULL) {
-        if (log_messages) {
-            printf("[EasyConnect] ERROR - No IP address\n");
-        }
-        return NULL;
-    }
-
-    if (log_messages) {
-        printf("[EasyConnect] IP address %s\n", ip_addr);
-    }
-    return network_interface;
-}
-
+/* \brief easy_connect - easy_connect function to connect the pre-defined network bearer,
+ *                       config done via mbed_app.json (see README.md for details).
+ * IN: bool  log_messages  print out diagnostics or not.
+ *     char* WiFiSSID      WiFi SSID - by default NULL, but if it's NULL
+ *                         then MBED_CONF_APP_WIFI_SSID will be used
+ *     char* WiFiPassword  WiFi Password - by default NULL, but if it's NULL
+ *                         then MBED_CONF_APP_WIFI_PASSWORD will be used
+ */
+NetworkInterface* easy_connect(bool log_messages,
+                               char* WiFiSSID,
+                               char* WiFiPassword);
 #endif // __EASY_CONNECT_H__

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -29,6 +29,11 @@
 #define MESH_THREAD       102
 #define CELLULAR_ONBOARD  201
 
+// Define different Nucleo X Wifi  module types
+// The mbed_app.json MBED_CONF_IDW0XX1_EXPANSION_BOARD needs this
+#define IDW01M1           1
+#define IDW01A1           2
+
 /* Define supersets for WiFi and Mesh */
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
@@ -66,27 +71,6 @@
 #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 
 #endif // (EASY_CONNECT_MESH)
-
-// In case the mbed_app.json only defined WIFI SSID/PASSWORD, not ESP8266 ones.
-#if not defined MBED_CONF_APP_ESP8266_SSID
-#define MBED_CONF_APP_ESP8266_SSID         MBED_CONF_APP_WIFI_SSID
-#else
-#define MBED_CONF_APP_WIFI_PASSWORD        MBED_CONF_APP_ESP8266_PASSWORD
-#endif
-
-#if not defined MBED_CONF_APP_ESP8266_PASSWORD
-#define MBED_CONF_APP_ESP8266_PASSWORD     MBED_CONF_APP_WIFI_PASSWORD
-#else
-#define MBED_CONF_APP_WIFI_SSID            MBED_CONF_APP_ESP8266_SSID
-#endif
-
-#if not defined MBED_CONF_APP_ESP8266_TX
-#define MBED_CONF_APP_ESP8266_TX         MBED_CONF_APP_WIFI_TX
-#endif
-
-#if not defined MBED_CONF_APP_ESP8266_RX
-#define MBED_CONF_APP_ESP8266_RX         MBED_CONF_APP_WIFI_RX
-#endif
 
 /* \brief print_MAC - print_MAC  - helper function to print out MAC address
  * in: network_interface - pointer to network i/f

--- a/easy-connect.h
+++ b/easy-connect.h
@@ -32,25 +32,25 @@
 /* Define supersets for WiFi and Mesh */
 
 #if MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ESP8266
-#define WIFI
+#define EASY_CONNECT_WIFI
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_ODIN
-#define WIFI
+#define EASY_CONNECT_WIFI
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_RTW
-#define WIFI
+#define EASY_CONNECT_WIFI
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == WIFI_IDW0XX1
-#define WIFI
+#define EASY_CONNECT_WIFI
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_LOWPAN_ND
-#define MESH
+#define EASY_CONNECT_MESH
 
 #elif MBED_CONF_APP_NETWORK_INTERFACE == MESH_THREAD
-#define MESH
+#define EASY_CONNECT_MESH
 #endif // MBED_CONF_APP_NETWORK_INTERFACE
 
-#if defined(MESH)
+#if defined(EASY_CONNECT_MESH)
 
 // Define macros for radio type
 #define ATMEL   1
@@ -65,7 +65,7 @@
 // This is address to mbed Device Connector
 #define MBED_SERVER_ADDRESS "coap://api.connector.mbed.com:5684"
 
-#endif // (MESH)
+#endif // (EASY_CONNECT_MESH)
 
 // In case the mbed_app.json only defined WIFI SSID/PASSWORD, not ESP8266 ones.
 #if not defined MBED_CONF_APP_ESP8266_SSID

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,9 +1,38 @@
 {
     "name": "easy-connect",
+    "config": {
+        "wifi-esp8266-tx": {
+            "help": "TX pin for serial connection to external device (ESP8266)",
+            "value": "D1"
+        },
+        "wifi-esp8266-rx": {
+            "help": "RX pin for serial connection to external device (ESP8266)",
+            "value": "D0"
+        },
+        "wifi-esp8266-debug": {
+            "help": "Enable debug logs for (ESP8266)",
+            "value": false
+        },
+        "wifi-idw01m1-tx": {
+            "help": "TX pin for serial connection to external device (WIFI-X-Nucleo-IDW01M1)",
+            "value": "PA_9"
+        },
+        "wifi-idw01m1-rx": {
+            "help": "RX pin for serial connection to external device (WIFI-X-Nucleo-IDW01M1)",
+            "value": "PA_10"
+        },
+        "wifi-idw01a1-tx": {
+            "help": "TX pin for serial connection to external device (WIFI-X-Nucleo-IDW01A1)",
+            "value": "D8"
+        },
+        "wifi-idw01a1-rx": {
+            "help": "RX pin for serial connection to external device (WIFI-X-Nucleo-IDW01A1)",
+            "value": "D2"
+        }
+    },
     "target_overrides": {
         "*": {
             "target.features_add": ["COMMON_PAL"]
         }
     }
 }
-


### PR DESCRIPTION
A more pure .h/.cpp separation - implementation in the .cpp file
and the defines in the .h file.

Added also now the option to include WiFi SSID, Password as params
via an overloaded function. There is now logic to deduce if the
params were given and they were - those will be used.

If the paramers were note given (and we're using WiFi) we will
revert using the params given in the `mbed_app.json` -file.

That should sort out issue #56.

Rebased on top of the no-password commit by Andrew Chong, however
I think the the comparison should >1 rather than >2 - the password
could be just one character as well.