### PR TITLE
Hexiwear ESP8266 & Nucleo F4x1RE pins to mbed_lib.json

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -33,6 +33,10 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["COMMON_PAL"]
+        },
+         "HEXIWEAR": {
+            "wifi-esp8266-tx": "PTD3",
+            "wifi-esp8266-rx": "PTD2"
         }
-    }
+     }
 }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -37,6 +37,14 @@
          "HEXIWEAR": {
             "wifi-esp8266-tx": "PTD3",
             "wifi-esp8266-rx": "PTD2"
+        },
+        "NUCLEO_F401RE": {
+            "wifi-esp8266-tx": "D8",
+            "wifi-esp8266-rx": "D2"
+        },
+        "NUCLEO_F411RE": {
+            "wifi-esp8266-tx": "D8",
+            "wifi-esp8266-rx": "D2"
         }
      }
 }


### PR DESCRIPTION
It needs the pin defines now, it does not have the standard D0/D1.