### PR TITLE
Modified compile bug when use ARMCC6

### DIFF
--- a/wizfi310-driver.lib
+++ b/wizfi310-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wizfi310-driver/#e78ec79cf496133c2afe4196d953b69af5b3c6ab
+https://github.com/ARMmbed/wizfi310-driver/#e0f7b9355e7e23daaa2d3f1d5c389c52528d6178


### PR DESCRIPTION
Hi~ WizFi310 driver has a bug when it is compiled on ARMCC6. 
So I modified this bug.