### PR TITLE
rm drivers which have been added to mbed-os

### DIFF
--- a/atmel-rf-driver.lib
+++ b/atmel-rf-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/atmel-rf-driver/#ca9782e68f5f47680b7ec82c3dcb60a98dd8e361

--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/esp8266-driver/#5a88ff9c75e34d65e359d7f239bacc456824ed0e

--- a/mcr20a-rf-driver.lib
+++ b/mcr20a-rf-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mcr20a-rf-driver/#17c467b64ab604887fc160cbe4118a51477e334b


### PR DESCRIPTION
ESP8266: https://github.com/ARMmbed/mbed-os/commit/fc5bf5986b88bd055a952acf225ff2a869b3d0e8
MCR20A RF: https://github.com/ARMmbed/mbed-os/commit/b5240db10d4fe835472db8bba1b2fc27808d30e4
Atmel RF: https://github.com/ARMmbed/mbed-os/commit/d02097f97c272350b00a2d41374c535209223905